### PR TITLE
max-width fix

### DIFF
--- a/atom/snippets.cson
+++ b/atom/snippets.cson
@@ -151,7 +151,7 @@
 
 	'macian-small':
 		'prefix': 'macian-small'
-		'body': '@media screen and (min-width: 30em) {\n\t$1\n}'
+		'body': '@media screen and (max-width: 30em) {\n\t$1\n}'
 
 	'macian-medium':
 		'prefix': 'macian-medium'

--- a/css/macian.border.css
+++ b/css/macian.border.css
@@ -55,7 +55,7 @@
               inset 0 -8px 12px -8px rgba(0, 0, 0, 0.2)
 }
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .ba-s {border-style:        solid; border-width:        .125em}
   .bt-s {border-top-style:    solid; border-top-width:    .125em}

--- a/css/macian.box.height.css
+++ b/css/macian.box.height.css
@@ -20,7 +20,7 @@
 .xh4 {max-height: 40%} .xh5 {max-height: 50%} .xh6 {max-height: 60%}
 .xh7 {max-height: 70%} .xh8 {max-height: 80%} .xh9 {max-height: 90%}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .ha-s {height: auto} .hf-s {height: 100%} .vh-s {height: 100vh}
 

--- a/css/macian.box.margin.css
+++ b/css/macian.box.margin.css
@@ -39,7 +39,7 @@
 .mh6 {margin-left:   8em; margin-right:   8em}
 .mh7 {margin-left:  16em; margin-right:  16em}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .m0-s {margin:    0} .m1-s {margin: .25em}
   .m2-s {margin: .5em} .m3-s {margin:   1em}

--- a/css/macian.box.padding.css
+++ b/css/macian.box.padding.css
@@ -41,7 +41,7 @@
 .ph6 {padding-left:   8em; padding-right:   8em}
 .ph7 {padding-left:  16em; padding-right:  16em}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .p0-s {padding:    0} .p1-s {padding: .25em}
   .p2-s {padding: .5em} .p3-s {padding:   1em}

--- a/css/macian.box.width.css
+++ b/css/macian.box.width.css
@@ -20,7 +20,7 @@
 .xw4 {max-width: 40%} .xw5 {max-width: 50%} .xw6 {max-width: 60%}
 .xw7 {max-width: 70%} .xw8 {max-width: 80%} .xw9 {max-width: 90%}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .wa-s {width: auto} .wf-s {width: 100%} .vw-s {width: 100vw}
 

--- a/css/macian.display.css
+++ b/css/macian.display.css
@@ -18,7 +18,7 @@
 .o2 {opacity: .2} .o1 {opacity: .1}
 .o0 {opacity:  0}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .dn-s  {display: none}
   .db-s  {display: block}

--- a/css/macian.layout.css
+++ b/css/macian.layout.css
@@ -17,7 +17,7 @@
 
 .rf {float: right} .lf {float: left}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .a0-s {top: 0; right: 0; bottom: 0; left: 0}
 

--- a/css/macian.misc.css
+++ b/css/macian.misc.css
@@ -25,7 +25,7 @@
   border-bottom: .125em solid #ddd;
 }
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .cover-s   {background-size: cover   !important}
   .contain-s {background-size: contain !important}

--- a/css/macian.type.css
+++ b/css/macian.type.css
@@ -63,7 +63,7 @@ ul, ol, .lspi {list-style-position: inside}
 .lss  {list-style-type: square}
 .lsn  {list-style: none}
 
-@media screen and (min-width: 30em) {
+@media screen and (max-width: 30em) {
 
   .f1-s {font-size: 2.6179em} .f2-s {font-size: 2.0581em}
   .f3-s {font-size:  1.618em} .f4-s {font-size:  1.272em}


### PR DESCRIPTION
Hey there! I know I've told you before that I love Macian. I love using it especially when building prototypes where I need some quick layouts and some minimal styles. 

I noticed recently that the `*-s` classes weren't working as expected and took a look and saw why: with media queries, 'min-width' is "this size and above", where as 'max-width' behaves like "this size and below", so all of the `*-s` classes were not behaving as expected. This commit makes all of the `*-s` classes apply their styles for all screens `30em` and below now :D 

What do you use to minify the CSS for npm consumption? I didn't touch the `macian.min.css` and would like to get that updated too as a part of this PR.